### PR TITLE
load elf segments according to paddr

### DIFF
--- a/src/commands/LoadFile.c
+++ b/src/commands/LoadFile.c
@@ -312,11 +312,11 @@ u8 FlashBuffer[MaxFlashSize] = {0};
 void LoadElfSegments() {
   for (int i=0; i<ElfHeader.phnum; i++) {
     struct ElfProgramHeader *header = (struct ElfProgramHeader *) (ElfProgramHeaders + (i*ElfHeader.phentsize));
-    if (header->type == 1  &&  header->vaddr < 0x800000) { // >= 0x800000 is avr trick for non-flash areas
+    if (header->type == 1  &&  header->paddr < 0x800000) { // >= 0x800000 is avr trick for non-flash areas
 
       if (!header->offset)                               {Fail("Flash memory image missing in ELF file.");}
       if (header->filesize > header->memsize)            {Fail("ELF file error: filesize>memsize.");}
-      if (header->vaddr + header->memsize > FlashSize()) {Fail("Flash segment extends beyond available flash on this device.");}
+      if (header->paddr + header->memsize > FlashSize()) {Fail("Flash segment extends beyond available flash on this device.");}
 
       Seek(CurrentFile, header->offset);
       int length = Read(CurrentFile, FlashBuffer, header->filesize);
@@ -328,14 +328,14 @@ void LoadElfSegments() {
 
       Ws("Loading "); Wd(header->memsize,1);
       Ws(" flash bytes from ELF text segment "); Wd(i,1);
-      Ws(" to addresses $"); Wx(header->vaddr,1);
-      Ws(" through $"); Wx(header->vaddr+header->memsize-1,1); Wsl(".");
-      WriteFlash(header->vaddr, FlashBuffer, header->memsize);
+      Ws(" to addresses $"); Wx(header->paddr,1);
+      Ws(" through $"); Wx(header->paddr+header->memsize-1,1); Wsl(".");
+      WriteFlash(header->paddr, FlashBuffer, header->memsize);
     }
   }
 
   // Set PC to start address of first ELF segment
-  PC = ((struct ElfProgramHeader*)ElfProgramHeaders)->vaddr;
+  PC = ((struct ElfProgramHeader*)ElfProgramHeaders)->paddr;
 }
 
 


### PR DESCRIPTION
It took me a while to get to the bottom of this, but apparently vaddr is the location that an elf section is relocated to by the code's startup in clib. paddr is where the section needs to be loaded to. This is important for initialized data (to something other than 0).

Example: [sensor.zip](https://github.com/dcwbrown/dwire-debug/files/781928/sensor.zip)

For this particular code loading that segment makes all the difference in the world. When the data is not initialized, the behavior is undefined.

By the way, the quantity of text that scrolls by from the load command seems excessive since the one line that matters (the first) gets lost off the top of the screen. Perhaps this would be a good place to use your dots code (perhaps one dot per page loaded).