### PR TITLE
use TOOLCHAIN_DIR variable to cross-compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 #PATH := /bin
 
+# set variable TOOLCHAIN_DIR to cross compile
+# example: https://github.com/raspberrypi/tools
+# make TOOLCHAIN_DIR=<tools>/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64
+
 # Uncomment the following line to remove the Linux dependency on GTK
 #NOFILEDIALOG:=1
 
@@ -11,6 +15,11 @@ else
 BINARY := $(TARGET)
 
 #autodetect FILEDIALOG options for Linux based on existance of gtk+-3.0
+CC = gcc
+ifdef  TOOLCHAIN_DIR
+       CC := $(wildcard $(TOOLCHAIN_DIR)/bin/*-gcc)
+       NOFILEDIALOG:=1
+endif
 ifndef NOFILEDIALOG
        FILEDIALOG := $(shell pkg-config --exists gtk+-3.0 && echo \`pkg-config --cflags --libs gtk+-3.0\`)
 endif
@@ -25,11 +34,13 @@ endif
 .PHONY: run
 .PHONY: install
 
+ifndef TOOLCHAIN_DIR
 #all: clean run
 all: run
 
 run: $(BINARY)
 	./$(BINARY) f0,q
+endif
 
 $(BINARY): */*/*.c */*.c Makefile
 ifdef WINDIR
@@ -40,12 +51,14 @@ else
 	#i686-w64-mingw32-gcc -g -oo -std=gnu99 -Wall -o $(BINARY) -Dwindows src/$(TARGET).c -lKernel32 -lComdlg32
 endif
 else
-	gcc -std=gnu99 -g -fno-pie -rdynamic -fPIC -Wall -o $(BINARY) src/$(TARGET).c $(FILEDIALOG)
+	$(CC) -std=gnu99 -g -fno-pie -rdynamic -fPIC -Wall -o $(BINARY) src/$(TARGET).c $(FILEDIALOG)
 endif
 	ls -lap $(BINARY)
 
 clean:
 	-rm -rf *.o *.map *.list $(BINARY)
 
+ifndef TOOLCHAIN_DIR
 install:
 	cp -p $(BINARY) /usr/local/bin
+endif


### PR DESCRIPTION
I've been using a Raspberry Pi to debug not only in circuit but remotely! I have some devices that are connected to sensors and send data by NRF24 radios. By placing a Raspberry Pi next to them I can connect by ssh to load firmware, etc. This makes it possible to control both ends of the connection from one place instead of running up and down flight of stairs or so.

To support cross-compile, I added an argument that points to the toolchain. I put in a comment that shows how to use it for raspbian, but I think it should work for other toolchains as well. Cross compilation configuration seems confusing to me, so I tried to do it in a simple way.

A related idea I had is that gpio pins on the serial device could be handy, particularly when everything is remote. For example, they could be used to power cycle the device under test (the whole thing, not just the microcontroller) in order to debug booting problems. I noticed the FT232 has a pin marked DTR on it's connector, so I'll look into using it for this purpose. If this turns out to be useful, it would be handy for any replacement to have similar functionality.