### PR TITLE
Add support for MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dwdebug
 *.o
 ref/*
 avrdude.conf
+dwdebug.dSYM/Contents/Info.plist

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -16,7 +16,7 @@ This program is free software: you can redistribute it and/or modify it under th
 
 ##### Cross-platform
 
-Built and tested on Windows 10.1 and Ubuntu 15.04. USB UART support requires only standard system libraries. Digispark support requires libusb-win32 installed (e.g. by zadig, see below). 
+Built and tested on Windows 10.1, Ubuntu 15.04 and macOS 10.13.6. USB UART support requires only standard system libraries. Digispark support requires libusb-win32 installed (e.g. by zadig, see below). 
 
 ##### Target device support
 
@@ -40,6 +40,8 @@ Build on linux with a conventional gcc/make setup. The binary produced is `dwdeb
 Build on Windows with MinGW-w64 under cygwin. I install 32 bit cygwin and use cygwin setup to add the mingw64-i686-binutils and mingw-i686-gcc-core packages. The binary produced is `dwdebug.exe`.
 
 On Linux the build requires libusb-dev installed.
+
+On MacOS the build requires `brew install libusb libusb-compat`
 
 File chooser: If the `load` command is used without a parameter, dwdebug will display the MS windows or GTK file chooser. (If running on a linux system with no GTK support installed the `load` command requires a filename parameter.)
 
@@ -77,7 +79,7 @@ For an in-circuit connection, the Vcc power line is not connected, and setting t
 
 ##### Digispark/Littlewire hardware with extended USBtinySPI firmware
 
-DWEN must be programmed on the t85 in the digispark/littlewire device. All the digisparks I have seen do not have this programmed, so you will need to use (borrow?) an ISP programmer to set this fuse.
+RSTDISBL must be programmed on the t85 in the digispark/littlewire device. All the digisparks I have seen do not have this programmed, so you will need to use (borrow?) an ISP programmer to set this fuse.
 
 Olimex's version of the digipark has pin 1/reset/dw open circuit - but this is easily fixed with a solder bridge on the pcb trace on the bottom side of the board.
 

--- a/src/commands/DeviceCommand.c
+++ b/src/commands/DeviceCommand.c
@@ -13,7 +13,7 @@ void DeviceFail(char *msg) {
   Wsl("  com5");
   Wsl("  usbtiny1");
   Wsl("  ttyUSB3");
-  Wsl("  usbserial-AD01SU081");
+  Wsl("  tty.usbserial-A700ONFG");
   Wl();
   Wsl("The device name may be abbreviated to as little as its first letter, thus");
   Wsl("the examples above could be specified instead as c5, u1 and t3.");

--- a/src/commands/DeviceCommand.c
+++ b/src/commands/DeviceCommand.c
@@ -13,6 +13,7 @@ void DeviceFail(char *msg) {
   Wsl("  com5");
   Wsl("  usbtiny1");
   Wsl("  ttyUSB3");
+  Wsl("  usbserial-AD01SU081");
   Wl();
   Wsl("The device name may be abbreviated to as little as its first letter, thus");
   Wsl("the examples above could be specified instead as c5, u1 and t3.");
@@ -34,7 +35,19 @@ void DeviceCommand(void) {
 
   char devicename[32];
   Ra(devicename, sizeof(devicename));
+#if defined(__APPLE__)
+  char * pch1, * pch2;
+  pch1 = strstr (InputBuffer,"tty.usbserial-");
+  if (pch1){
+    n = strtol(pch1+14, 0, 16);
+    pch2 = strstr (pch1," ");
+    if (pch2) {
+      IOut = IOut + (int)(pch2-pch1)-2;
+    }
+  }
+#else
   if (IsNumeric(NextCh())) n = ReadNumber(0);
+#endif
   Sb();
   if (IsNumeric(NextCh())) baud = ReadNumber(0);
 
@@ -51,7 +64,8 @@ void DeviceCommand(void) {
       ||  (strncasecmp(devicename, "usbtinyspi", l) == 0)) {
     DwFindPort('u', n, 0);
   } else if (    (strncasecmp(devicename, "com",    l) == 0)
-             ||  (strncasecmp(devicename, "ttyusb", l) == 0)) {
+             ||  (strncasecmp(devicename, "ttyusb", l) == 0)
+             ||  (strncasecmp(devicename, "usbserial", l) == 0)) {
     DwFindPort('s', n, baud);
   } else {
     DeviceFail("Unrecognised device id.");

--- a/src/commands/LoadFile.c
+++ b/src/commands/LoadFile.c
@@ -85,6 +85,13 @@ struct stab {
   u32 value;   // value of symbol.
 };
 
+//stab (debugging data table)
+
+void TrimFunctionDetails(char *fn) {
+  while(*fn  &&  *fn != ':') {fn++;}
+  if (fn[0] && fn[1] && fn[2]) {fn[0]='('; fn[1]=')'; fn[2]=0;}
+}
+
 
 char SourceFilename[300] = {0};
 
@@ -242,14 +249,6 @@ int IsLoadableElf(void) {
       }
       p += symbolTableHeader->entsize;
     }
-  }
-
-
-  //stab (debugging data table)
-
-  void TrimFunctionDetails(char *fn) {
-    while(*fn  &&  *fn != ':') {fn++;}
-    if (fn[0] && fn[1] && fn[2]) {fn[0]='('; fn[1]=')'; fn[2]=0;}
   }
 
   int FunctionOffset = 0;

--- a/src/dwire/DwPort.c
+++ b/src/dwire/DwPort.c
@@ -236,6 +236,8 @@ void DescribePort(int i) {
   if (Ports[i]->kind == 's') {
     #if windows
       Ws("COM");
+    #elif defined(__APPLE__)
+      Ws("/dev/tty.usbserial");
     #else
       Ws("/dev/ttyUSB");
     #endif

--- a/src/dwire/Serial.c
+++ b/src/dwire/Serial.c
@@ -63,6 +63,32 @@ struct SPort {  // Serial port
 
     Free(DosDevices);
   }
+  
+#elif defined(__APPLE__)  
+
+  void FindSerials(void) {
+    DIR *DeviceDir = opendir("/dev");
+    if (!DeviceDir) return;
+
+    struct dirent *entry = 0;
+    struct SPort *p;
+    while ((entry = readdir(DeviceDir))) {
+      if (!strncmp("tty.usbserial", entry->d_name, 6)) {
+        Assert((p = malloc(sizeof(struct SPort))));
+
+        p->port.kind      = 's';
+        p->port.index     = strtol(entry->d_name+14, 0, 16);
+        p->port.character = -1;   // Currently undetermined
+        p->port.baud      = 0;    // Currently undetermined
+        p->handle         = 0;    // Currently unconnected
+        snprintf(p->portname, sizeof(p->portname), "%s", entry->d_name);
+
+        Ports[PortCount] = (struct Port *)p;
+        PortCount++;
+      }
+    }
+    closedir(DeviceDir);
+  }
 
 #else
 

--- a/src/dwire/Serial.c
+++ b/src/dwire/Serial.c
@@ -125,6 +125,9 @@ void SerialSendBytes(struct SPort *port, const u8 *out, int outlen) {
   // up in the receive buffer (unless there is a collision). Drain this
   // echoed input and check that it has not been changed.
   u8 actual[outlen];
+  #if defined(__APPLE__)
+  usleep(50*1000); //let byte arrive on mac
+  #endif
   SerialRead(port->handle, actual, outlen);
   for (int i=0; i<outlen; i++) {
     if (actual[i] != out[i]) {

--- a/src/system/SerialPort.c
+++ b/src/system/SerialPort.c
@@ -53,7 +53,7 @@
     }
     struct termios config = {0};
     if (tcgetattr(*SerialPort, &config) == -1) {Close(*SerialPort); *SerialPort = 0; return;}
-    config.c_cflag     = CS8 | BOTHER | CLOCAL;
+    config.c_cflag     = CS8 | CLOCAL;
     config.c_iflag     = IGNPAR | IGNBRK;
     config.c_oflag     = 0;
     config.c_lflag     = 0;

--- a/src/system/SerialPort.c
+++ b/src/system/SerialPort.c
@@ -125,6 +125,10 @@ if (period < 1) period = 1;
   usleep(period*1000);
   ioctl(port, TIOCCBRK);
 #endif
+
+#if defined(__APPLE__)
+  usleep(50*1000); //let 1st byte arrive on mac
+#endif
 }
 
 void SerialDump(FileHandle port) {

--- a/src/system/SerialPort.c
+++ b/src/system/SerialPort.c
@@ -46,7 +46,9 @@
   }
 #elif defined(__APPLE__)
   void MakeSerialPort(char *portname, int baudrate, FileHandle *SerialPort) {
-    if ((*SerialPort = open(portname, O_RDWR/*|O_NONBLOCK|O_NDELAY*/)) < 0) {
+    char serialFullPath[64] = "/dev/";
+    strcat (serialFullPath, portname);
+    if ((*SerialPort = open(serialFullPath, O_RDWR|O_NONBLOCK|O_NDELAY)) < 0) {
       Ws("Couldn't open serial port "); Ws(portname); Fail(".");
     }
     struct termios config = {0};

--- a/src/system/SerialPort.c
+++ b/src/system/SerialPort.c
@@ -57,16 +57,18 @@
     config.c_iflag     = IGNPAR | IGNBRK;
     config.c_oflag     = 0;
     config.c_lflag     = 0;
-    config.c_ispeed    = baudrate;
-    config.c_ospeed    = baudrate;
+    //config.c_ispeed    = baudrate;
+    //config.c_ospeed    = baudrate;
     config.c_cc[VMIN]  = 0;           // Return as soon as one byte is available
     config.c_cc[VTIME] = 5;           // 0.5 seconds timeout per byte
     speed_t speed = baudrate; // Set 14400 baud
+    
+    if (tcsetattr(*SerialPort, TCSANOW, &config) == -1) {Close(*SerialPort); *SerialPort = 0; return;}
     if (ioctl(*SerialPort, IOSSIOSPEED, &speed) == -1) {
         printf("Error calling ioctl(..., IOSSIOSPEED, ...) %s - %s(%d).\n",
                portname, strerror(errno), errno);
-    }   
-    if (tcsetattr(*SerialPort, TCSANOW, &config) == -1) {Close(*SerialPort); *SerialPort = 0; return;}
+    }
+    
     usleep(10000); // Allow 10ms for USB to settle.
     ioctl(*SerialPort, TCFLSH, TCIOFLUSH);
   }

--- a/src/system/SerialPort.c
+++ b/src/system/SerialPort.c
@@ -40,6 +40,10 @@
 
     WinOK(SetCommTimeouts(*SerialPort, &(COMMTIMEOUTS){300,300,1,300,1}));
   }
+#elif defined(__APPLE__)  
+  void MakeSerialPort(char *portname, int baudrate, FileHandle *SerialPort) {
+    //todo:
+  }
 #else
   void MakeSerialPort(char *portname, int baudrate, FileHandle *SerialPort) {
     if ((*SerialPort = open(portname, O_RDWR/*|O_NONBLOCK|O_NDELAY*/)) < 0) {
@@ -87,6 +91,8 @@ if (period < 1) period = 1;
   WinOK(SetCommBreak(port));
   Sleep(period);
   WinOK(ClearCommBreak(port));
+#elif defined(__APPLE__)  
+  //todo:
 #else
   ioctl(port, TCFLSH, TCIOFLUSH);
   ioctl(port, TIOCSBRK);

--- a/src/system/SystemServices.c
+++ b/src/system/SystemServices.c
@@ -28,8 +28,12 @@
   #include <errno.h>
   #include <sys/select.h>
   #include <dirent.h>
+#ifdef __APPLE__
+  #include <termios.h>
+#else
   #include <stropts.h>
   #include <asm/termios.h>
+#endif
   #include <setjmp.h>
   #include <dlfcn.h>
   void delay(unsigned int ms) {usleep(ms*1000);}

--- a/src/system/SystemUSB.c
+++ b/src/system/SystemUSB.c
@@ -90,6 +90,9 @@
   // Linux - USB support is built in.
 
   #include <usb.h>
+  
+  // run the following command on mac to fix 'usb.h' file not found
+  // brew install libusb libusb-compat 
 
   int UsbInit() {usb_init(); return 1;}
 


### PR DESCRIPTION
Tested with Attiny13+FT232 and Attiny13+Digispark

I guess there is a latency in FT232's mac driver. The program needs to wait 10~20ms after data received. Otherwise, the program reads nothing and throwing an error.