### PR TITLE
fix: modern linux distributions does not have stropts.h

### DIFF
--- a/src/system/SystemServices.c
+++ b/src/system/SystemServices.c
@@ -31,8 +31,10 @@
 #ifdef __APPLE__
   #include <termios.h>
 #else
+#ifndef __linux__
   #include <stropts.h>
-  #include <asm/termios.h>
+#endif
+#include <asm/termios.h>
 #endif
   #include <setjmp.h>
   #include <dlfcn.h>


### PR DESCRIPTION
```
gcc -std=gnu99 -g -fno-pie -rdynamic -fPIC -Wall -o dwdebug src/dwdebug.c -lusb -ldl
In file included from src/system/system.c:1,
                 from src/dwdebug.c:3:
src/system/SystemServices.c:34:12: fatal error: stropts.h: No such file or directory
   34 |   #include <stropts.h>
      |            ^~~~~~~~~~~
compilation terminated.
make: *** [Makefile:48: dwdebug] Error 1

```